### PR TITLE
Implement search and detail pages

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -4,8 +4,10 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Code-Save{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link rel="stylesheet" href="{% static 'css/styles.css' %}">
 </head>
 <body>
 
@@ -45,7 +47,10 @@
 <!--      <li><a href="{% url 'core:pesquisa' %}">Pesquisa</a></li>-->
 <!--    </ul>-->
 
-    {% block content %} {% endblock %}
+    <div class="container mt-4">
+        {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    <script src="{% static 'js/scripts.js' %}"></script>
 </body>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 </html>

--- a/core/templates/detalhe.html
+++ b/core/templates/detalhe.html
@@ -1,8 +1,24 @@
 {% extends "base.html" %}
-
-
+{% block title %}{{ detalhe.nome }} - Detalhe{% endblock %}
 {% block content %}
-
-  <h1>Detalhe</h1>
-
+<div class="card">
+  <div class="card-header bg-primary text-white d-flex justify-content-between">
+    <h2 class="mb-0">{{ detalhe.nome }}</h2>
+    <span class="badge bg-secondary">{{ detalhe.tipo }}</span>
+  </div>
+  <div class="card-body">
+    <p class="mb-3">{{ detalhe.descricao }}</p>
+    {% if detalhe.exemplo %}
+    <div class="code-block"><pre><code>{{ detalhe.exemplo }}</code></pre></div>
+    {% endif %}
+    <p><strong>Linguagem:</strong> {{ detalhe.linguagem.nome }}</p>
+    <p><strong>Palavras-chave:</strong> {{ detalhe.palavraChave }}</p>
+    <p><strong>Data de criação:</strong> {{ detalhe.dataCriacao|date:"d/m/Y H:i" }}</p>
+    <p><strong>Última edição:</strong> {{ detalhe.dataEdicao|date:"d/m/Y H:i" }}</p>
+    <div class="mt-3 d-flex gap-2">
+      <a href="{% url 'core:editar_nota' detalhe.id %}" class="btn btn-secondary">Editar</a>
+      <a href="{% url 'core:lista_notas' %}" class="btn btn-primary">Voltar</a>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/core/templates/pesquisa.html
+++ b/core/templates/pesquisa.html
@@ -1,8 +1,44 @@
 {% extends "base.html" %}
-
-
+{% block title %}Pesquisar{% endblock %}
 {% block content %}
+<h2 class="mb-4">Pesquisar Notas</h2>
+<form method="get" class="row g-3 mb-4">
+  <div class="col-md-4">
+    <input type="text" class="form-control" name="q" placeholder="Palavra-chave" value="{{ query }}">
+  </div>
+  <div class="col-md-3">
+    <select class="form-select" name="linguagem">
+      <option value="">Linguagem</option>
+      {% for ling in linguagens %}
+        <option value="{{ ling.id }}" {% if linguagem_id|default:'' == ling.id|stringformat:'s' %}selected{% endif %}>{{ ling.nome }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-3">
+    <select class="form-select" name="tipo">
+      <option value="">Tipo</option>
+      <option value="Comando" {% if 'Comando' in tipos %}selected{% endif %}>Comando</option>
+      <option value="Função" {% if 'Função' in tipos %}selected{% endif %}>Função</option>
+      <option value="Biblioteca" {% if 'Biblioteca' in tipos %}selected{% endif %}>Biblioteca</option>
+      <option value="Outro" {% if 'Outro' in tipos %}selected{% endif %}>Outro</option>
+    </select>
+  </div>
+  <div class="col-md-2 d-grid">
+    <button type="submit" class="btn btn-primary">Buscar</button>
+  </div>
+</form>
 
-  <h1>Pesquisa</h1>
-
+{% if notas %}
+  {% for nota in notas %}
+    <div class="card mb-3">
+      <div class="card-body">
+        <h5 class="card-title"><a href="{% url 'core:detalhe' nota.id %}">{{ nota.nome }}</a></h5>
+        <p class="card-text">{{ nota.descricao|truncatewords:25 }}</p>
+        <small class="text-muted">{{ nota.tipo }} - {{ nota.linguagem.nome }}</small>
+      </div>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>Nenhum resultado encontrado.</p>
+{% endif %}
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render, redirect, get_object_or_404
+from django.db.models import Q
 from .forms import NotaForm
 from django.utils.timezone import now
 from .models import Linguagem, Nota
@@ -47,7 +48,36 @@ def detalhe(request, pk):
     return render(request, 'detalhe.html', context)
 
 def pesquisa(request):
-    return render(request, 'pesquisa.html')
+    notas = Nota.objects.all().order_by('-dataEdicao')
+    linguagens = Linguagem.objects.all()
+
+    query = request.GET.get('q', '')
+    tipos = request.GET.getlist('tipo')
+    linguagem_id = request.GET.get('linguagem', '')
+
+    if query:
+        notas = notas.filter(
+            Q(nome__icontains=query)
+            | Q(descricao__icontains=query)
+            | Q(exemplo__icontains=query)
+            | Q(palavraChave__icontains=query)
+        )
+
+    if tipos:
+        notas = notas.filter(tipo__in=tipos)
+
+    if linguagem_id:
+        notas = notas.filter(linguagem_id=linguagem_id)
+
+    context = {
+        'notas': notas,
+        'linguagens': linguagens,
+        'query': query,
+        'tipos': tipos,
+        'linguagem_id': linguagem_id,
+    }
+
+    return render(request, 'pesquisa.html', context)
 
 
 def lista_notas(request):


### PR DESCRIPTION
## Summary
- load site CSS/JS and containerize pages
- add detailed note view template
- implement search template with filters
- implement search logic in view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6843694eace88324918c24b78f59d4da