### PR TITLE
Add language management page and links

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Nota
+from .models import Nota, Linguagem
 
 class NotaForm(forms.ModelForm):
     class Meta:
@@ -15,4 +15,13 @@ class NotaForm(forms.ModelForm):
             'tipo': forms.TextInput(attrs={'class': 'form-control'}),
             'nome': forms.TextInput(attrs={'class': 'form-control'}),
             'linguagem': forms.TextInput(attrs={'class': 'form-control'}),
+        }
+
+
+class LinguagemForm(forms.ModelForm):
+    class Meta:
+        model = Linguagem
+        fields = ['nome']
+        widgets = {
+            'nome': forms.TextInput(attrs={'class': 'form-control'}),
         }

--- a/core/templates/adicionar_linguagem.html
+++ b/core/templates/adicionar_linguagem.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Nova Linguagem{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6">
+    <div class="card">
+      <div class="card-header bg-primary text-white">
+        <h2 class="mb-0">Adicionar Linguagem</h2>
+      </div>
+      <form method="post" class="p-3">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        <div class="mb-3">
+          <label for="id_nome" class="form-label">Nome</label>
+          {{ form.nome }}
+        </div>
+        <div class="text-end">
+          <a href="{% url 'core:cadastro' %}" class="btn btn-secondary me-2">Cancelar</a>
+          <button type="submit" class="btn btn-primary">Salvar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/core/templates/cadastro.html
+++ b/core/templates/cadastro.html
@@ -35,12 +35,15 @@
                     <!-- Campo linguagem (select dinâmico do banco) -->
                     <div class="mb-3">
                         <label for="{{ form.linguagem.id_for_label }}" class="form-label">Linguagem/Tecnologia</label>
-                        <select class="form-select" id="linguagem" name="linguagem" required>
-                            <option value="" selected disabled>Selecione a linguagem</option>
-                            {% for linguagem in linguagens %}
-                                <option value="{{ linguagem.id }}">{{ linguagem.nome }}</option>
-                            {% endfor %}
-                        </select>
+                        <div class="input-group">
+                            <select class="form-select" id="linguagem" name="linguagem" required>
+                                <option value="" selected disabled>Selecione a linguagem</option>
+                                {% for linguagem in linguagens %}
+                                    <option value="{{ linguagem.id }}">{{ linguagem.nome }}</option>
+                                {% endfor %}
+                            </select>
+                            <a href="{% url 'core:adicionar_linguagem' %}" class="btn btn-outline-secondary" title="Adicionar linguagem">+</a>
+                        </div>
                     </div>
 
                     <!-- Campo descrição -->

--- a/core/templates/editar_nota.html
+++ b/core/templates/editar_nota.html
@@ -26,12 +26,15 @@
           </div>
           <div class="mb-3">
             <label for="{{ form.linguagem.id_for_label }}" class="form-label">Linguagem/Tecnologia</label>
-            <select class="form-select" id="linguagem" name="linguagem" required>
-              <option value="" disabled>Selecione a linguagem</option>
-              {% for linguagem in linguagens %}
-                <option value="{{ linguagem.id }}" {% if linguagem.id == form.instance.linguagem.id %}selected{% endif %}>{{ linguagem.nome }}</option>
-              {% endfor %}
-            </select>
+            <div class="input-group">
+              <select class="form-select" id="linguagem" name="linguagem" required>
+                <option value="" disabled>Selecione a linguagem</option>
+                {% for linguagem in linguagens %}
+                  <option value="{{ linguagem.id }}" {% if linguagem.id == form.instance.linguagem.id %}selected{% endif %}>{{ linguagem.nome }}</option>
+                {% endfor %}
+              </select>
+              <a href="{% url 'core:adicionar_linguagem' %}" class="btn btn-outline-secondary" title="Adicionar linguagem">+</a>
+            </div>
           </div>
           <div class="mb-3">
             <label for="{{ form.descricao.id_for_label }}" class="form-label">Descrição *</label>

--- a/core/templates/lista_notas.html
+++ b/core/templates/lista_notas.html
@@ -6,6 +6,7 @@
     <h2 class="mb-0">Todas as Notas</h2>
     <a href="{% url 'core:cadastro' %}" class="btn btn-primary">Nova Nota</a>
   </div>
+  <div class="table-responsive">
   <table class="table table-striped">
     <thead>
       <tr>
@@ -36,5 +37,6 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endblock %}

--- a/core/templates/pesquisa.html
+++ b/core/templates/pesquisa.html
@@ -7,12 +7,15 @@
     <input type="text" class="form-control" name="q" placeholder="Palavra-chave" value="{{ query }}">
   </div>
   <div class="col-md-3">
-    <select class="form-select" name="linguagem">
-      <option value="">Linguagem</option>
-      {% for ling in linguagens %}
-        <option value="{{ ling.id }}" {% if linguagem_id|default:'' == ling.id|stringformat:'s' %}selected{% endif %}>{{ ling.nome }}</option>
-      {% endfor %}
-    </select>
+    <div class="input-group">
+      <select class="form-select" name="linguagem">
+        <option value="">Linguagem</option>
+        {% for ling in linguagens %}
+          <option value="{{ ling.id }}" {% if linguagem_id|default:'' == ling.id|stringformat:'s' %}selected{% endif %}>{{ ling.nome }}</option>
+        {% endfor %}
+      </select>
+      <a href="{% url 'core:adicionar_linguagem' %}" class="btn btn-outline-secondary" title="Adicionar linguagem">+</a>
+    </div>
   </div>
   <div class="col-md-3">
     <select class="form-select" name="tipo">

--- a/core/urls.py
+++ b/core/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path('notas/', views.lista_notas, name='lista_notas'),
     path('nota/<int:pk>/editar/', views.editar_nota, name='editar_nota'),
     path('nota/<int:pk>/excluir/', views.excluir_nota, name='excluir_nota'),
+    path('linguagem/nova/', views.adicionar_linguagem, name='adicionar_linguagem'),
 
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Q
-from .forms import NotaForm
+from .forms import NotaForm, LinguagemForm
 from django.utils.timezone import now
 from .models import Linguagem, Nota
 
@@ -109,3 +109,15 @@ def excluir_nota(request, pk):
         nota.delete()
         return redirect('core:lista_notas')
     return redirect('core:lista_notas')
+
+
+def adicionar_linguagem(request):
+    if request.method == 'POST':
+        form = LinguagemForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('core:cadastro')
+    else:
+        form = LinguagemForm()
+
+    return render(request, 'adicionar_linguagem.html', {'form': form})


### PR DESCRIPTION
## Summary
- enable managing programming language entries through a new `adicionar_linguagem` view
- show "add language" buttons beside language fields in cadastro, edição e pesquisa
- wrap list table in responsive container

## Testing
- `pip install -r requirements.txt`
- `python3 manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68436ae3d298832486b707f070a814f8