### PR TITLE
Fix login redirect URL

### DIFF
--- a/codesaveapp/settings.py
+++ b/codesaveapp/settings.py
@@ -127,3 +127,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Where to redirect users after successful login
+LOGIN_REDIRECT_URL = '/profile/'
+# URL used by the @login_required decorator for unauthenticated users
+LOGIN_URL = '/login/'


### PR DESCRIPTION
## Summary
- configure login redirect in Django settings

## Testing
- `pytest -q`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6843961846c08324b39c9e24f5509619