### PR TITLE
Implement password reset and remember-me

### DIFF
--- a/core/templates/login.html
+++ b/core/templates/login.html
@@ -375,7 +375,7 @@
 
                     <!-- Link Esqueceu Senha -->
                     <div class="forgot-password">
-                        <a href="#" onclick="showForgotPassword()">
+                        <a href="javascript:showForgotPassword()">
                             <i class="fas fa-key me-1"></i>
                             Esqueceu sua senha?
                         </a>
@@ -384,7 +384,7 @@
                     <!-- Link Registrar -->
                     <div class="register-link">
                         <p class="mb-2">Ainda não tem uma conta?</p>
-                        <a href="#" onclick="showRegister()">
+                        <a href="javascript:showRegister()">
                             <i class="fas fa-user-plus me-2"></i>
                             Criar conta grátis
                         </a>
@@ -464,13 +464,11 @@
 
     // Funções de navegação (adapte conforme suas URLs)
     function showForgotPassword() {
-        alert('Redirecionando para recuperação de senha...');
-        // window.location.href = '{% url "password_reset" %}';
+        window.location.href = '{% url "password_reset" %}';
     }
 
     function showRegister() {
-        alert('Redirecionando para cadastro...');
-        // window.location.href = '{% url "register" %}';
+        window.location.href = '{% url "core:register" %}';
     }
 
     // Efeito de parallax suave no fundo

--- a/core/templates/password_reset.html
+++ b/core/templates/password_reset.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Recuperar Senha{% endblock %}
+
+{% block content %}
+<h2>Recuperar senha</h2>
+<p>Informe seu email para receber o link de redefinição.</p>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Enviar</button>
+</form>
+{% endblock %}

--- a/core/templates/password_reset_complete.html
+++ b/core/templates/password_reset_complete.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block title %}Senha Alterada{% endblock %}
+
+{% block content %}
+<h2>Senha redefinida com sucesso</h2>
+<p>Você já pode fazer login com sua nova senha.</p>
+<a href="{% url 'core:login' %}" class="btn btn-primary">Ir para login</a>
+{% endblock %}

--- a/core/templates/password_reset_confirm.html
+++ b/core/templates/password_reset_confirm.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}Nova Senha{% endblock %}
+
+{% block content %}
+<h2>Defina sua nova senha</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Alterar senha</button>
+</form>
+{% endblock %}

--- a/core/templates/password_reset_done.html
+++ b/core/templates/password_reset_done.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}Email Enviado{% endblock %}
+
+{% block content %}
+<h2>Verifique seu email</h2>
+<p>Se existir uma conta para o email informado, enviaremos instruções para redefinir sua senha.</p>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,6 @@
 from core import views
 from django.urls import path
+from django.contrib.auth import views as auth_views
 
 app_name = 'core'
 
@@ -17,5 +18,18 @@ urlpatterns = [
     path('register/', views.register, name='register'),
     path('profile/', views.profile, name='profile'),
     path('dashboard/', views.dashboard, name='dashboard'),
+
+    path('password_reset/', auth_views.PasswordResetView.as_view(
+        template_name='password_reset.html'
+    ), name='password_reset'),
+    path('password_reset/done/', auth_views.PasswordResetDoneView.as_view(
+        template_name='password_reset_done.html'
+    ), name='password_reset_done'),
+    path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(
+        template_name='password_reset_confirm.html'
+    ), name='password_reset_confirm'),
+    path('reset/done/', auth_views.PasswordResetCompleteView.as_view(
+        template_name='password_reset_complete.html'
+    ), name='password_reset_complete'),
 
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -133,6 +133,18 @@ def adicionar_linguagem(request):
 class UserLoginView(LoginView):
     template_name = 'login.html'
 
+    def form_valid(self, form):
+        """Set session expiry based on the 'remember' checkbox."""
+        remember = self.request.POST.get("remember")
+        if remember:
+            # Keep the user logged in for two weeks
+            self.request.session.set_expiry(60 * 60 * 24 * 14)
+        else:
+            # Session expires when the browser closes
+            self.request.session.set_expiry(0)
+
+        return super().form_valid(form)
+
 
 class UserLogoutView(LogoutView):
     next_page = 'core:index'


### PR DESCRIPTION
## Summary
- enable remember-me handling on login
- add built-in password reset flow and templates
- connect login page links to password reset and registration pages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6843984a19b48324b17959ae854b0937