### PR TITLE
Fix password reset link in login page

### DIFF
--- a/core/templates/login.html
+++ b/core/templates/login.html
@@ -464,7 +464,7 @@
 
     // Funções de navegação (adapte conforme suas URLs)
     function showForgotPassword() {
-        window.location.href = '{% url "password_reset" %}';
+        window.location.href = '{% url "core:password_reset" %}';
     }
 
     function showRegister() {


### PR DESCRIPTION
## Summary
- correct the password reset URL to include the `core` namespace

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6843993ec7688324836bab678585e8f0